### PR TITLE
DROOLS-1025 - AddRemove rules tests - don't reuse KieBase when adding rules

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AbstractAddRemoveRulesTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AbstractAddRemoveRulesTest.java
@@ -110,7 +110,10 @@ public abstract class AbstractAddRemoveRulesTest {
                     session = createNewSession((String[]) testOperationParameter, resultsList, additionalGlobals);
                     break;
                 case ADD_RULES:
-                    addRulesToSession(session, (String[]) testOperationParameter);
+                    addRulesToSession(session, (String[]) testOperationParameter, false);
+                    break;
+                case ADD_RULES_REINSERT_OLD:
+                    addRulesToSession(session, (String[]) testOperationParameter, true);
                     break;
                 case REMOVE_RULES:
                     removeRulesFromSession(session, (String[]) testOperationParameter);
@@ -165,10 +168,16 @@ public abstract class AbstractAddRemoveRulesTest {
         return session;
     }
 
-    private void addRulesToSession(final StatefulKnowledgeSession session, final String[] drls) {
+    private void addRulesToSession(final StatefulKnowledgeSession session, final String[] drls,
+            final boolean reimportAllRules) {
         for (String drl : drls) {
-            final KnowledgeBuilder kbuilder2 = createKnowledgeBuilder(session.getKieBase(), drl);
-            session.getKieBase().addKnowledgePackages(kbuilder2.getKnowledgePackages());
+            final KnowledgeBuilder kBuilder;
+            if (reimportAllRules) {
+                kBuilder = createKnowledgeBuilder(session.getKieBase(), drl);
+            } else {
+                kBuilder = createKnowledgeBuilder(null, drl);
+            }
+            session.getKieBase().addKnowledgePackages(kBuilder.getKnowledgePackages());
         }
     }
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveRulesTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveRulesTest.java
@@ -1181,10 +1181,10 @@ public class AddRemoveRulesTest extends AbstractAddRemoveRulesTest {
                 .addOperation(TestOperationType.CHECK_RESULTS, new String[]{RULE1_NAME})
                 .addOperation(TestOperationType.ADD_RULES, new String[]{rule2})
                 .addOperation(TestOperationType.FIRE_RULES)
-                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{RULE1_NAME, RULE2_NAME})
+                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{RULE2_NAME})
                 .addOperation(TestOperationType.ADD_RULES, new String[]{rule3})
                 .addOperation(TestOperationType.FIRE_RULES)
-                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{RULE1_NAME, RULE2_NAME, RULE3_NAME})
+                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{RULE3_NAME})
                 .addOperation(TestOperationType.REMOVE_RULES, new String[]{RULE1_NAME, RULE2_NAME, RULE3_NAME})
                 .addOperation(TestOperationType.FIRE_RULES)
                 .addOperation(TestOperationType.CHECK_RESULTS, new String[]{});
@@ -1240,7 +1240,7 @@ public class AddRemoveRulesTest extends AbstractAddRemoveRulesTest {
                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{RULE1_NAME, RULE3_NAME})
                .addOperation(TestOperationType.ADD_RULES, new String[]{rule2})
                .addOperation(TestOperationType.FIRE_RULES)
-               .addOperation(TestOperationType.CHECK_RESULTS, new String[]{RULE1_NAME, RULE2_NAME, RULE3_NAME});
+               .addOperation(TestOperationType.CHECK_RESULTS, new String[]{RULE2_NAME});
 
         runAddRemoveTest(builder.build(), new HashMap<String, Object>());
     }

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveTestBuilder.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveTestBuilder.java
@@ -54,7 +54,10 @@ public class AddRemoveTestBuilder {
         // Same with reverted rules
         testPlan.addAll(createInsertFactsRemoveRulesFireRulesRemoveRulesTestPlan(rule2, rule1, rule2Name, rule1Name, facts));
 
-        // TODO - more permutations.
+        // Session with rules -> Insert facts -> Fire -> Check results -> Remove rule(s) -> Fire -> Reinsert rules -> Check results
+        testPlan.addAll(createInsertFactsFireRulesRemoveRulesReinsertRulesTestPlan(rule1, rule2, rule1Name, rule2Name, facts));
+        // Same with reverted rules
+        testPlan.addAll(createInsertFactsFireRulesRemoveRulesReinsertRulesTestPlan(rule2, rule1, rule2Name, rule1Name, facts));
 
         return testPlan;
     }
@@ -83,25 +86,6 @@ public class AddRemoveTestBuilder {
                 .addOperation(TestOperationType.REMOVE_RULES, new String[]{rule2Name})
                 .addOperation(TestOperationType.FIRE_RULES)
                 .addOperation(TestOperationType.CHECK_RESULTS, new String[]{});
-        testPlan.add(builder.build());
-
-        builder = new AddRemoveTestBuilder();
-        builder.addOperation(TestOperationType.CREATE_SESSION, new String[]{rule1, rule2})
-                .addOperation(TestOperationType.INSERT_FACTS, facts)
-                .addOperation(TestOperationType.FIRE_RULES)
-                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{rule1Name, rule2Name})
-                .addOperation(TestOperationType.REMOVE_RULES, new String[]{rule1Name})
-                .addOperation(TestOperationType.FIRE_RULES)
-                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{})
-                .addOperation(TestOperationType.REMOVE_RULES, new String[]{rule2Name})
-                .addOperation(TestOperationType.FIRE_RULES)
-                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{})
-                .addOperation(TestOperationType.ADD_RULES, new String[]{rule1})
-                .addOperation(TestOperationType.FIRE_RULES)
-                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{rule1Name})
-                .addOperation(TestOperationType.ADD_RULES, new String[]{rule2})
-                .addOperation(TestOperationType.FIRE_RULES)
-                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{rule1Name, rule2Name});
         testPlan.add(builder.build());
 
         builder = new AddRemoveTestBuilder();
@@ -203,6 +187,65 @@ public class AddRemoveTestBuilder {
         return testPlan;
     }
 
+    public static List<List<TestOperation>> createInsertFactsFireRulesRemoveRulesReinsertRulesTestPlan(final String rule1,
+            final String rule2, final String rule1Name, final String rule2Name, final Object[] facts) {
+        final List<List<TestOperation>> testPlan = new ArrayList<List<TestOperation>>();
+        AddRemoveTestBuilder builder = new AddRemoveTestBuilder();
+        builder.addOperation(TestOperationType.CREATE_SESSION, new String[]{rule1, rule2})
+                .addOperation(TestOperationType.INSERT_FACTS, facts)
+                .addOperation(TestOperationType.FIRE_RULES)
+                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{rule1Name, rule2Name})
+                .addOperation(TestOperationType.REMOVE_RULES, new String[]{rule1Name, rule2Name})
+                .addOperation(TestOperationType.FIRE_RULES)
+                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{})
+                .addOperation(TestOperationType.ADD_RULES, new String[]{rule1, rule2})
+                .addOperation(TestOperationType.FIRE_RULES)
+                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{rule1Name, rule2Name});
+        testPlan.add(builder.build());
+
+        builder = new AddRemoveTestBuilder();
+        builder.addOperation(TestOperationType.CREATE_SESSION, new String[]{rule1, rule2})
+                .addOperation(TestOperationType.INSERT_FACTS, facts)
+                .addOperation(TestOperationType.FIRE_RULES)
+                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{rule1Name, rule2Name})
+                .addOperation(TestOperationType.REMOVE_RULES, new String[]{rule1Name})
+                .addOperation(TestOperationType.FIRE_RULES)
+                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{})
+                .addOperation(TestOperationType.REMOVE_RULES, new String[]{rule2Name})
+                .addOperation(TestOperationType.FIRE_RULES)
+                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{})
+                .addOperation(TestOperationType.ADD_RULES, new String[]{rule1})
+                .addOperation(TestOperationType.FIRE_RULES)
+                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{rule1Name})
+                .addOperation(TestOperationType.ADD_RULES, new String[]{rule2})
+                .addOperation(TestOperationType.FIRE_RULES)
+                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{rule2Name})
+                .addOperation(TestOperationType.REMOVE_RULES, new String[]{rule1Name, rule2Name})
+                .addOperation(TestOperationType.FIRE_RULES)
+                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{});
+        testPlan.add(builder.build());
+
+        builder = new AddRemoveTestBuilder();
+        builder.addOperation(TestOperationType.CREATE_SESSION, new String[]{rule1, rule2})
+                .addOperation(TestOperationType.INSERT_FACTS, facts)
+                .addOperation(TestOperationType.FIRE_RULES)
+                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{rule1Name, rule2Name})
+                .addOperation(TestOperationType.REMOVE_RULES, new String[]{rule1Name})
+                .addOperation(TestOperationType.FIRE_RULES)
+                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{})
+                .addOperation(TestOperationType.REMOVE_RULES, new String[]{rule2Name})
+                .addOperation(TestOperationType.FIRE_RULES)
+                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{})
+                .addOperation(TestOperationType.ADD_RULES_REINSERT_OLD, new String[]{rule1})
+                .addOperation(TestOperationType.FIRE_RULES)
+                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{rule1Name})
+                .addOperation(TestOperationType.ADD_RULES_REINSERT_OLD, new String[]{rule2})
+                .addOperation(TestOperationType.FIRE_RULES)
+                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{rule1Name, rule2Name});
+        testPlan.add(builder.build());
+        return testPlan;
+    }
+
     public static List<TestOperation> createInsertFactsRemoveFireTestPlan(final String rule1, final String rule2,
             final Object[] facts) {
         final AddRemoveTestBuilder builder = new AddRemoveTestBuilder();
@@ -217,21 +260,7 @@ public class AddRemoveTestBuilder {
         return builder.build();
     }
 
-    public static List<TestOperation> createInsertFactsFireRemoveTestPlan(final String rule1, final String rule2,
-            final Object[] facts) {
-        final AddRemoveTestBuilder builder = new AddRemoveTestBuilder();
-        builder.addOperation(TestOperationType.CREATE_SESSION, new String[]{rule1, rule2})
-                .addOperation(TestOperationType.INSERT_FACTS, facts)
-                .addOperation(TestOperationType.FIRE_RULES)
-                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{"R1", "R2"})
-                .addOperation(TestOperationType.REMOVE_RULES, new String[]{"R2"})
-                .addOperation(TestOperationType.REMOVE_RULES, new String[]{"R1"})
-                .addOperation(TestOperationType.FIRE_RULES)
-                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{});
-        return builder.build();
-    }
-
     public static Object[] getDefaultFacts() {
-        return new Object[]{1, "1"};
+        return new Object[]{1, 2, "1"};
     }
 }

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/TestOperationType.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/TestOperationType.java
@@ -19,5 +19,5 @@ package org.drools.compiler.integrationtests.incrementalcompilation;
  * Represents possible test operations in incremental compilation tests.
  */
 public enum TestOperationType {
-    CREATE_SESSION, ADD_RULES, REMOVE_RULES, CHECK_RESULTS, FIRE_RULES, INSERT_FACTS
+    CREATE_SESSION, ADD_RULES, ADD_RULES_REINSERT_OLD, REMOVE_RULES, CHECK_RESULTS, FIRE_RULES, INSERT_FACTS
 }


### PR DESCRIPTION
- Changed default behaviour of adding rules - when adding a rule, rules from session are not reinserted. 
- Added possibility to reinsert all existing rules from session when adding a rule. 
- There's 1 failure now:
  - AddRemoveRulesTest.testRemoveWithSplitStartDoubledIntegerConstraint - a rule fires when it shouldn't fire. 
  - Fails on second test plan in AddRemoveTestBuilder.createInsertFactsFireRulesRemoveRulesReinsertRulesTestPlan, 16th operation. The second rule is added, but also the first rule fires, although it was fired before (now the rules are added without using KieBase from the session, so they are not all reinserted). 
